### PR TITLE
feat: Add known IPv4 and IPv6 blocks to details

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,13 @@ returns a map with each region name as a key to an object:
 * a consistent 6 character abbreviation for the region of the format `xx-yyN`
 * a display name that should match the value given in the [docs](https://cloud.google.com/compute/docs/regions-zones#available)
 * an estimated latitude and longitude
+* a list of IPv4 and IPv6 CIDRs associated with the region
 
 No validation is performed to ensure a name represents an active or available Compute
 Engine region; in the event the name is not recognized, the display name will be
-`Unknown region` and the latitude and longitude fields will match those of the
-US Geological Survey marker in Kansas that represents the [historical center of
-the contiguous United States](https://www.google.com/maps/place/The+Geographic+Center+of+the+United+States/@39.8283459,-98.5816684,17z).
+`Unknown region`, the ipv4 and ipv6 CIDR lists will be empty, and the latitude
+and longitude fields will match those of the US Geological Survey marker in Kansas
+that represents the [historical center of the contiguous United States].
 
 > NOTE: If you think this is in error for a given region, please open an issue
 to get the region added.
@@ -27,7 +28,7 @@ to get the region added.
 ```hcl
 module "regions" {
     source  = "memes/region-detail/google"
-    version = "1.0.0"
+    version = "1.1.0"
     regions = ["us-west1", "us-central1"]
 }
 ```
@@ -41,12 +42,16 @@ results = {
     "display_name" = "Council Bluffs, Iowa"
     "latitude" = 41.237085
     "longitude" = -96.868656
+    "ipv4" = []
+    "ipv6" = []
   }
   "us-west1" = {
     "abbreviation" = "us-we1"
     "display_name" = "The Dalles, Oregon"
     "latitude" = 45.609235
     "longitude" = -121.205447
+    "ipv4" = []
+    "ipv6" = []
   }
 }
 ```
@@ -56,7 +61,7 @@ results = {
 ```hcl
 module "regions" {
     source  = "memes/multi-region-private-network/google//modules/regions"
-    version = "1.0.0"
+    version = "1.1.0"
     regions = ["foo-bar1"]
 }
 ```
@@ -70,6 +75,8 @@ results = {
     "display_name" = "Unknown region"
     "latitude" = 39.82835
     "longitude" = -98.5816737
+    "ipv4" = []
+    "ipv6" = []
   }
 }
 ```
@@ -81,6 +88,7 @@ results = {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2 |
+| <a name="requirement_http"></a> [http](#requirement\_http) | >= 3.2 |
 
 ## Modules
 
@@ -88,7 +96,9 @@ No modules.
 
 ## Resources
 
-No resources.
+| Name | Type |
+|------|------|
+| [http_http.cloud_json](https://registry.terraform.io/providers/hashicorp/http/latest/docs/data-sources/http) | data source |
 
 ## Inputs
 
@@ -103,3 +113,5 @@ No resources.
 | <a name="output_results"></a> [results](#output\_results) | For each supplied region, return an abbreviation for the name in the form<br>`xx-yyN`, a display name that matches the value listed in Google's documentation,<br>and a reasonable latitude and longitude for the region. In the event of a<br>region being unknown to the module, the returned latitude and longitude will<br>be for the historical geographic center of the contiguous 48 United States. |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 <!-- markdownlint-enable MD033 MD034 -->
+
+[historical center of the contiguous United States]: https://www.google.com/maps/place/The+Geographic+Center+of+the+United+States/@39.8283459,-98.5816684,17z

--- a/outputs.tf
+++ b/outputs.tf
@@ -6,6 +6,8 @@ output "results" {
     # contiguous United States marker.
     latitude  = try(local.locations[region].latitude, 39.82835)
     longitude = try(local.locations[region].longitude, -98.5816737)
+    ipv4      = try(local.locations[region].ipv4, [])
+    ipv6      = try(local.locations[region].ipv6, [])
   } }
   description = <<-EOD
     For each supplied region, return an abbreviation for the name in the form

--- a/test/integration/regions/controls/ipv4.rb
+++ b/test/integration/regions/controls/ipv4.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'ipaddr'
+require 'json'
+require 'rspec/expectations'
+
+RSpec::Matchers.define :be_ipv4_cidr do
+  match do |cidr|
+    IPAddr.new(cidr).ipv4?
+  end
+end
+
+control 'ipv4' do
+  title 'Ensure regions module results have IPv4 CIDRs'
+  impact 1.0
+  results = JSON.parse(input('output_results_json'), { symbolize_names: true }).transform_values do |value|
+    value[:ipv4]
+  end
+
+  only_if('Foo-bar1 test region does not have IPv4 CIDRs to verify') do
+    !results.include?(:'foo-bar1')
+  end
+
+  # NOTE: the published JSON changes frequently, so it is safer to test for the
+  # existence of results and that each entry is a valid IPv6 CIDR.
+  results.each do |_, cidrs|
+    describe cidrs do
+      it { should_not be_nil }
+      it { should_not be_empty }
+    end
+    cidrs.each do |cidr|
+      describe cidr do
+        it { should be_ipv4_cidr }
+      end
+    end
+  end
+end

--- a/test/integration/regions/controls/ipv6.rb
+++ b/test/integration/regions/controls/ipv6.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'ipaddr'
+require 'json'
+require 'rspec/expectations'
+
+RSpec::Matchers.define :be_ipv6_cidr do
+  match do |cidr|
+    IPAddr.new(cidr).ipv6?
+  end
+end
+
+control 'ipv6' do
+  title 'Ensure regions module results have IPv6 CIDRs'
+  impact 1.0
+  results = JSON.parse(input('output_results_json'), { symbolize_names: true }).transform_values do |value|
+    value[:ipv6]
+  end
+
+  only_if('Foo-bar1 test region does not have IPv6 CIDRs to verify') do
+    !results.include?(:'foo-bar1')
+  end
+
+  # NOTE: the published JSON changes frequently, so it is safer to test for the
+  # existence of results and that each entry is a valid IPv6 CIDR.
+  results.each do |_, cidrs|
+    describe cidrs do
+      it { should_not be_nil }
+      its('count') { should eq 1 }
+    end
+    cidrs.each do |cidr|
+      describe cidr do
+        it { should be_ipv6_cidr }
+      end
+    end
+  end
+end

--- a/test/integration/regions/controls/regions.rb
+++ b/test/integration/regions/controls/regions.rb
@@ -1,9 +1,18 @@
 # frozen_string_literal: true
 
+require 'json'
+
 control 'regions' do
   title 'Ensure regions module results match expectations'
   impact 1.0
-  results = JSON.parse(input('output_results_json'), { symbolize_names: true })
+  # Remove IPv4/IPv6 values from the results since those are tested in the other
+  # controls
+  results = JSON.parse(input('output_results_json'),
+                       { symbolize_names: true }).transform_values do |value|
+    value.reject do |k, _|
+      %i[ipv4 ipv6].include?(k)
+    end
+  end
   expected = JSON.parse(input('output_expected_json'), { symbolize_names: true })
 
   describe results do


### PR DESCRIPTION
Google publishes a set of IPv4 and IPv6 CIDR blocks that are used for public IP addreses in each Compute Engine region. This commit adds those values to the detail results in this module.

Closes #5